### PR TITLE
Change default logging level for root logger - tickets/INSTRM-2735

### DIFF
--- a/python/ics/cobraCharmer/cobraCoach/mcs/camera.py
+++ b/python/ics/cobraCharmer/cobraCoach/mcs/camera.py
@@ -14,7 +14,7 @@ from ics.utils.database.opdb import OpDB
 from ics.cobraCharmer.utils import butler
 
 # Configure the default formatter and logger.
-logging.basicConfig(datefmt = "%Y-%m-%d %H:%M:%S", level=logging.DEBUG,
+logging.basicConfig(datefmt = "%Y-%m-%d %H:%M:%S", level=logging.INFO,
                     format = "%(asctime)s.%(msecs)03dZ %(name)-16s %(levelno)s %(filename)s:%(lineno)d %(message)s")
 
 def whereAmI():


### PR DESCRIPTION
* Small change to make sure we don't see log messages from, e.g. matplotlib.

This shouldn't affect anything else because the `Camera` class sets the log level to `INFO` by default anyway.