### PR TITLE
Fix db access - tickets/INSTRM-2742

### DIFF
--- a/python/ics/cobraCharmer/cobraCoach/cobraCoach.py
+++ b/python/ics/cobraCharmer/cobraCoach/cobraCoach.py
@@ -6,6 +6,8 @@ from astropy.io import fits
 import pathlib
 import time
 
+from ics.utils.database.opdb import OpDB
+
 from ics.cobraCharmer.cobraCoach import calculus
 from ics.cobraCharmer.cobraCoach.speedModel import SpeedModel
 
@@ -65,7 +67,7 @@ class CobraCoach():
 
     def __init__(self, fpgaHost='localhost', loadModel=True, logLevel=logging.INFO,
                  trajectoryMode=False, rootDir=None, actor=None, cmd=None,
-                 simDataPath=None):
+                 simDataPath=None, db=None, dbParams=None):
         self.logger = logging.getLogger('cobraCoach')
         self.logger.setLevel(logLevel)
 
@@ -73,8 +75,7 @@ class CobraCoach():
         self.pfi = None
         self.cam = None
         self.fpgaHost = fpgaHost
-
-        
+        self.opdb = db or OpDB(dbParams)
 
         # scaling model
         self.useScaling = True
@@ -326,13 +327,13 @@ class CobraCoach():
             if self.actor is not None:
                 if self.simMode is False:
                     self.logger.info(f'MCS actor is given, try using mcsActor camera. simMode = {self.simMode}')
-                    self.cam = camera.cameraFactory(name='mcsActor',doClear=True, runManager=self.runManager,
-                                                    actor=self.actor, cmd=self.cmd)
+                    self.cam = camera.cameraFactory(name='mcsActor', doClear=True, runManager=self.runManager,
+                                                    actor=self.actor, cmd=self.cmd, db=self.opdb)
                 else:
                     self.logger.info(f'MCS actor is given, try using mcsActor camera in simulation mode')
-                    self.cam = camera.cameraFactory(name='mcsActor',doClear=True,
+                    self.cam = camera.cameraFactory(name='mcsActor', doClear=True,
                                                     runManager=self.runManager, actor=self.actor,
-                                                    cmd=self.cmd, simulationPath=self.simDataPath)
+                                                    cmd=self.cmd, db=self.opdb, simulationPath=self.simDataPath)
             else:
                 self.logger.info('MCS actor is not present, using RMOD camera')    
                 self.cam = camera.cameraFactory(name='rmod',doClear=True, runManager=self.runManager)


### PR DESCRIPTION
* The `Camera` class, the `cobraCoach`, and the `cameraFactory` accept either a `db` or `dbParams` for database.
* Remove bare `OpDB` call from `getPositionsForFrame` (the main issue for this ticket).

I am not sure if all the camera types need access to the db but I set up the factory so they would all be the same.

If neither `db` or `dbParams` are passed it will default to `OpDB` which currently connects to `pfsa-db`.

Note: this is not my favorite solution.