### PR TITLE
Remove unused import of factor_cmap

### DIFF
--- a/python/ics/cobraCharmer/cobraCoach/cobraCoach.py
+++ b/python/ics/cobraCharmer/cobraCoach/cobraCoach.py
@@ -1,6 +1,5 @@
 from importlib import reload
 import logging
-from bokeh.transform import factor_cmap
 import numpy as np
 from astropy.io import fits
 import pathlib


### PR DESCRIPTION
Hi!

I always have to comment this import because i don't have bokeh installed in my laptop. The import is not used at all, so it should not harm to remove it.