### PR TITLE
INSTRM-2978 Share one target validation between targeting and fps

### DIFF
--- a/python/ics/cobraCharmer/cobraCoach/build_maps_with_dots.py
+++ b/python/ics/cobraCharmer/cobraCoach/build_maps_with_dots.py
@@ -4,6 +4,7 @@ import pandas as pd
 import logging
 import pandas as pd
 from pfs.utils import butler
+from ics.cobraCharmer import targetValidation
 
 logging.basicConfig(format="%(asctime)s.%(msecs)03d %(levelno)s %(name)-10s %(message)s",
                     datefmt="%Y-%m-%dT%H:%M:%S")
@@ -112,7 +113,7 @@ def moveThetaPhi(cIds, thetas, phis, relative=False, local=True,
     elif not local:
         targetThetas[cIds] = (thetas - cc.calibModel.tht0[cIds]) % (np.pi*2)
         targetThetas[targetThetas < thetaMargin] += np.pi*2
-        thetaRange = (cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi
+        thetaRange = targetValidation.thetaRange(cc.calibModel)
         tooBig = targetThetas > thetaRange - thetaMargin
         targetThetas[tooBig] = thetaRange[tooBig] - thetaMargin
         targetPhis[cIds] = phis - cc.calibModel.phiIn[cIds] - np.pi
@@ -224,7 +225,7 @@ def moveThetaPhi2Steps(cIds, thetas, phis, relative=False, local=True,
     elif not local:
         thetas = (thetas - cc.calibModel.tht0[cIds]) % (np.pi*2)
         thetas[thetas < thetaMargin] += np.pi*2
-        thetaRange = ((cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi)[cIds]
+        thetaRange = targetValidation.thetaRange(cc.calibModel)[cIds]
         tooBig = thetas > thetaRange - thetaMargin
         thetas[tooBig] = thetaRange[tooBig] - thetaMargin
         phis -= cc.calibModel.phiIn[cIds] + np.pi

--- a/python/ics/cobraCharmer/cobraCoach/cobraCoach.py
+++ b/python/ics/cobraCharmer/cobraCoach/cobraCoach.py
@@ -9,6 +9,7 @@ from ics.cobraCharmer.cobraCoach.speedModel import SpeedModel
 
 from ics.cobraCharmer.cobraCoach.mcs import camera
 from ics.cobraCharmer import pfi as pfiControl
+from ics.cobraCharmer import targetValidation
 import ics.cobraCharmer.pfiDesign as pfiDesign
 from ics.cobraCharmer import func
 from ics.cobraCharmer.utils import butler as cbutler
@@ -16,7 +17,7 @@ from pfs.utils import butler
 import pfs.utils.coordinates.transform as transformUtils
 
 from pfs.utils.database import opdb
-import pandas as pd
+
 
 class CobraCoach():
     nCobrasPerModule = 57
@@ -103,7 +104,6 @@ class CobraCoach():
 
         self.frameNum = None
         self.expTime = None
-        self.cobraInterferenceTable = None
 
         butlerResource = butler.Butler()
 
@@ -134,7 +134,6 @@ class CobraCoach():
         self.phiInfoIsValid = False
 
         self.connect()
-        self.cobraInterferenceTable = self._loadcobraInterferenceTable()
 
     def setScaling(self, enabled=True, thetaScaleFactor=None, phiScaleFactor=None,
                    minThetaSteps=None, minPhiSteps=None, thetaScaling=None, phiScaling=None):
@@ -355,157 +354,34 @@ class CobraCoach():
 
         return cIds
 
-    def _loadcobraInterferenceTable(self):
-        '''Load the cobra interference table from the database and return a DataFrame with cobra indices.'''
-
-        butlerResource = butler.Butler()
-        df = pd.read_csv(butlerResource.getPath("cobraInterferenced"))
-
-        # Remove 'SC' from 'Module #' and 'PID' from 'Cobra ID'
-        df["Module #"] = df["Module #"].str.replace("SC", "", regex=False)
-        df["Cobra ID"] = df["Cobra ID"].str.replace("PID", "", regex=False)
-        df = df[df["comments"] != "no collision"]
-
-        # Convert 'Module #' and 'Cobra ID' to integers
-        df["Module #"] = df["Module #"].astype(int)
-        df["Cobra ID"] = df["Cobra ID"].astype(int)
-        df["Cobra Index"] = df.apply(
-            lambda row: self.calibModel.findCobraByModuleAndPositioner(row["Module #"], row["Cobra ID"]),
-            axis=1
-        )
-
-        # Reorder columns to move 'Cobra Index' to third column
-        cols = df.columns.tolist()
-        cols.insert(2, cols.pop(cols.index("Cobra Index")))
-        df = df[cols]
-
-        return df
-
     def checkFiducialInterference(self, thetas, phis, unassignedCobraIndexies=None):
-        """Check if the targets interfere with the fiducial fiber.
-        
-        Returns:
-            list: Indices of cobra arms that have interference/collision
+        """Cobra indices whose arm would interfere with a fiducial fiber.
+
+        Deprecated shim.  The implementation is targetValidation.fiducialInterference,
+        which works in (nCobras,) throughout; prefer calling it directly.  This
+        signature forces callers to subset to goodIdx and then map the returned
+        indices back, which is what it is kept only to avoid breaking.
+
+        thetas/phis are local angles for self.goodIdx, as before.
         """
-        
-        if self.cobraInterferenceTable is None:
-            if self.calibModel is None:
-                self.logger.warning("Cobra interference table is not available.")
-                return []
-            self.cobraInterferenceTable = self._loadcobraInterferenceTable()
+        fidAvoidance = targetValidation.loadFidAvoidance()
 
-        if self.cobraInterferenceTable is not None:
-            df = self.cobraInterferenceTable
-        else:
-            self.logger.warning("Cobra interference table is not available.")
-            return []
-
-        # Check the number of thetas and phis match the number of good cobras
-        self.logger.info(f"Number of thetas: {len(thetas)}, Number of phis: {len(phis)}, "
-                            f"Number of good cobras: {len(self.goodIdx)}")
-
-        # Convert theta and phi values from radians to degrees
-        thetas_deg = np.rad2deg((thetas+self.calibModel.tht0[self.goodIdx]) % (2 * np.pi))
-        phis_deg = np.rad2deg(phis % np.pi)
-
-        # Track cobra indices with interference
-        interfering_cobra_indices = []
-        interference_warnings = []
-        
-
-        for i, (theta_deg, phi_deg) in enumerate(zip(thetas_deg, phis_deg)):
-            # Get the goodIdx for this theta/phi position
-            cobra_idx = self.goodIdx[i]
-            # Find matching rows in the interference DataFrame for this cobra
-            matching_rows = df[df["Cobra Index"] == cobra_idx]
-
-            if not matching_rows.empty:
-                cobra_has_interference = False
-                
-                for _, row in matching_rows.iterrows():
-                    # Determine if theta is within the forbidden range (handle wrap-around)
-                    theta_in_range = False
-                    end_angle_in_range = False
-                    
-                    if 'theta limit 1' in df.columns and 'theta limit 2' in df.columns:
-                        theta_limit_1 = row['theta limit 1']
-                        theta_limit_2 = row['theta limit 2']
-
-                        if not (pd.isna(theta_limit_1) or pd.isna(theta_limit_2)):
-                            if theta_limit_1 > theta_limit_2:
-                                if theta_deg >= theta_limit_1 or theta_deg <= theta_limit_2:
-                                    theta_in_range = True
-                            else:
-                                if theta_limit_1 <= theta_deg <= theta_limit_2:
-                                    theta_in_range = True
-
-                            L1 = self.calibModel.L1[cobra_idx]
-                            L2 = self.calibModel.L2[cobra_idx]
-                            ang1 = self.calibModel.tht0[cobra_idx] + np.deg2rad(theta_deg)
-                            ang2 = ang1 + np.deg2rad(phi_deg) + self.calibModel.phiIn[cobra_idx]
-                            endAngle = np.rad2deg(np.angle(L1 * np.exp(1j * ang1) + L2 * np.exp(1j * ang2)) - self.calibModel.tht0[cobra_idx]) % 360
-
-                            if theta_limit_1 > theta_limit_2:
-                                if endAngle >= theta_limit_1 or endAngle <= theta_limit_2:
-                                    end_angle_in_range = True
-                            else:
-                                if theta_limit_1 <= endAngle <= theta_limit_2:
-                                    end_angle_in_range = True
-
-                    # Only consider interference when BOTH: theta is in the forbidden range AND phi exceeds the max phi
-                    if 'max phi angle for full theta circular motion' in df.columns and theta_in_range:
-                        max_phi_angle = row['max phi angle for full theta circular motion']
-
-                        if not pd.isna(max_phi_angle) and phi_deg > max_phi_angle:
-                            warning_msg = (f"WARNING: Cobra {cobra_idx} theta angle {theta_deg:.2f}° "
-                                           f"is within interference limits [{theta_limit_1:.2f}°, {theta_limit_2:.2f}°] "
-                                           f"and phi angle {phi_deg:.2f}° exceeds max {max_phi_angle:.2f}°")
-                            interference_warnings.append(warning_msg)
-                            cobra_has_interference = True
-
-                    # Also treat the cobra as interfering if the phi-arm endpoint angle falls in the forbidden range.
-                    if 'max phi angle for full theta circular motion' in df.columns and end_angle_in_range:
-                        max_phi_angle = row['max phi angle for full theta circular motion']
-
-                        if not pd.isna(max_phi_angle) and phi_deg > max_phi_angle:
-                            warning_msg = (f"WARNING: Cobra {cobra_idx} theta angle {theta_deg:.2f}° and phi angle {phi_deg:.2f}° "
-                                            f"end angle {endAngle:.2f}° "
-                                            f"is within interference limits [{theta_limit_1:.2f}°, {theta_limit_2:.2f}°]")
-                            interference_warnings.append(warning_msg)
-                            cobra_has_interference = True
-                        
-
-
-                # Add to interfering list if this cobra has any interference
-                if cobra_has_interference and cobra_idx not in interfering_cobra_indices:
-                    interfering_cobra_indices.append(cobra_idx)
-
-        # Log or raise warnings if interferences are found
-        if interference_warnings:
-            for warning in interference_warnings:
-                if hasattr(self, 'logger'):
-                    self.logger.warning(warning)
-                else:
-                    print(warning)
-        else:
-            if hasattr(self, 'logger'):
-                self.logger.info("No fiducial interference detected for the given theta and phi angles")
-            else:
-                print("No fiducial interference detected for the given theta and phi angles")
-        
+        # Angles are passed straight through: converting them to positions and back
+        # could resolve to the other branch in the overlapping region and change the
+        # verdict.  Unassigned cobras become NaN rather than dummy zeros plus a filter
+        # list, so they drop out natively.
+        allThetas = np.full(self.nCobras, np.nan)
+        allPhis = np.full(self.nCobras, np.nan)
+        allThetas[self.goodIdx] = thetas
+        allPhis[self.goodIdx] = phis
         if unassignedCobraIndexies is not None:
-            unassigned_set = set(np.asarray(unassignedCobraIndexies).tolist())
-            filtered_indices = []
-            for idx in interfering_cobra_indices:
-                if idx not in unassigned_set:
-                    filtered_indices.append(idx)
-                    self.logger.info(f"Cobra {idx} has fiducial interference and is not in unassigned list, adding to interfering cobras.")
-            interfering_cobra_indices = filtered_indices
+            allThetas[np.asarray(unassignedCobraIndexies, dtype=int)] = np.nan
 
-        
-        self.logger.info(f"Total number of cobras with fiducial interference: {len(interfering_cobra_indices)}")     
-        self.logger.info(f"Indices of cobras with fiducial interference: {interfering_cobra_indices}")   
-        return interfering_cobra_indices
+        hit = targetValidation.fiducialInterferenceFromAngles(
+            self.calibModel, allThetas, allPhis, fidAvoidance)
+        idx = np.flatnonzero(hit).tolist()
+        self.logger.info(f"Total number of cobras with fiducial interference: {len(idx)}")
+        return idx
 
     def exposeAndExtractPositions(self, name=None, guess=None, tolerance=None, 
                                   exptime=None, dbMatch = True, writeData = None, doStack=False):
@@ -1255,9 +1131,7 @@ class CobraCoach():
             if noMCS is True:
                 self.logger.info('noMCS flag is passed, set angles instead of exposure.')
                 if thetaEnable:
-                    thetaHome = ((self.calibModel.tht1 - self.calibModel.tht0 + np.pi)
-                                  % (np.pi*2) + np.pi)
-                    thetaHome = thetaHome[cIds]
+                    thetaHome = targetValidation.thetaRange(self.calibModel)[cIds]
                 else:
                     thetaHome = None
                 if phiEnable:

--- a/python/ics/cobraCharmer/cobraCoach/engineer.py
+++ b/python/ics/cobraCharmer/cobraCoach/engineer.py
@@ -14,6 +14,7 @@ from ics.cobraCharmer.cobraCoach import calculation
 import astropy.io.fits as pyfits
 
 import time
+from ics.cobraCharmer import targetValidation
 
 
 logging.basicConfig(format="%(asctime)s.%(msecs)03d %(levelno)s %(name)-10s %(message)s",
@@ -312,7 +313,7 @@ def moveThetaPhi(cIds, thetas, phis, relative=False, local=True,
                  tolerance=0.1, tries=6, homed=False,
                  newDir=True, thetaFast=False, phiFast=False,
                  threshold=10.0, thetaMargin=np.deg2rad(15.0),
-                 phiRamp=None, thetaRamp=None, hideLockIter=None):
+                 phiRamp=None, thetaRamp=None):
     """
     move cobras to the target angles
 
@@ -397,7 +398,7 @@ def moveThetaPhi(cIds, thetas, phis, relative=False, local=True,
     elif not local:
         targetThetas[cIds] = (thetas - cc.calibModel.tht0[cIds]) % (np.pi*2)
         targetThetas[targetThetas < thetaMargin] += np.pi*2
-        thetaRange = (cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi
+        thetaRange = targetValidation.thetaRange(cc.calibModel)
         tooBig = targetThetas > thetaRange - thetaMargin
         targetThetas[tooBig] = thetaRange[tooBig] - thetaMargin
         targetPhis[cIds] = phis - cc.calibModel.phiIn[cIds] - np.pi
@@ -418,8 +419,8 @@ def moveThetaPhi(cIds, thetas, phis, relative=False, local=True,
     # reappearance is almost always a partially-occluded edge centroid
     # or an IK-driven yo-yo — refining further only causes oscillation.
     # Sticky: once frozen, a cobra stays frozen for the rest of the loop.
-    # Caller can override via hideLockIter; default is tries // 2.
-    HIDE_LOCK_ITER = hideLockIter if hideLockIter is not None else tries // 2
+    # Frozen for the last four iterations of the loop.
+    HIDE_LOCK_ITER = max(0, tries - 4)
 
     cc.camResetStack(f'Stack.fits')
     logger.info(f'Move theta arms to angle={np.round(np.rad2deg(targetThetas[cIds]),2)} degree')
@@ -561,7 +562,7 @@ def convergenceTest(cIds, runs=8,
     targets = np.zeros((runs, len(cIds), 2))
     moves = np.zeros((runs, len(cIds), tries), dtype=moveDtype)
     positions = np.zeros((runs, len(cIds)), dtype=complex)
-    thetaRange = ((cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi)[cIds]
+    thetaRange = targetValidation.thetaRange(cc.calibModel)[cIds]
     phiRange = ((cc.calibModel.phiOut - cc.calibModel.phiIn) % (np.pi*2))[cIds]
 
     for i in range(runs):
@@ -1831,7 +1832,7 @@ def convergenceTestX(cIds, runs=3, thetaMargin=np.deg2rad(15.0), phiMargin=np.de
     targets = np.zeros((runs, len(cIds), 2))
     moves = np.zeros((runs, len(cIds), tries), dtype=moveDtype)
     positions = np.zeros((runs, len(cIds)), dtype=complex)
-    thetaRange = ((cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi)[cIds]
+    thetaRange = targetValidation.thetaRange(cc.calibModel)[cIds]
     phiRange = ((cc.calibModel.phiOut - cc.calibModel.phiIn) % (np.pi*2))[cIds]
 
     for i in range(runs):
@@ -1926,7 +1927,7 @@ def convergenceTest2(cIds, runs=8, thetaMargin=np.deg2rad(15.0), phiMargin=np.de
     targets = np.zeros((runs, len(cIds), 2))
     moves = np.zeros((runs, len(cIds), tries), dtype=moveDtype)
     positions = np.zeros((runs, len(cIds)), dtype=complex)
-    thetaRange = ((cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi)[cIds]
+    thetaRange = targetValidation.thetaRange(cc.calibModel)[cIds]
     phiRange = ((cc.calibModel.phiOut - cc.calibModel.phiIn) % (np.pi*2))[cIds]
     cm = cIds % 57
     cf = cIds % 798
@@ -1995,7 +1996,7 @@ def convergenceTestX2(cIds, runs=3, thetaMargin=np.deg2rad(15.0), phiMargin=np.d
     targets = np.zeros((runs, len(cIds), 2))
     moves = np.zeros((runs, len(cIds), tries), dtype=moveDtype)
     positions = np.zeros((runs, len(cIds)), dtype=complex)
-    thetaRange = ((cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi)[cIds]
+    thetaRange = targetValidation.thetaRange(cc.calibModel)[cIds]
     phiRange = ((cc.calibModel.phiOut - cc.calibModel.phiIn) % (np.pi*2))[cIds]
     ydir = np.angle(cc.calibModel.centers[1] - cc.calibModel.centers[55])
 
@@ -2066,7 +2067,7 @@ def createTrajectory(cIds, thetas, phis, tries=8, twoSteps=False, threshold=20.0
     targets = np.zeros((len(cIds), 2))
     moves = np.zeros((len(cIds), tries), dtype=moveDtype)
     positions = np.zeros(len(cIds), dtype=complex)
-    thetaRange = ((cc.calibModel.tht1 - cc.calibModel.tht0 + np.pi) % (np.pi*2) + np.pi)[cIds]
+    thetaRange = targetValidation.thetaRange(cc.calibModel)[cIds]
     phiRange = ((cc.calibModel.phiOut - cc.calibModel.phiIn) % (np.pi*2))[cIds]
 
     targets[:,0] = thetas

--- a/python/ics/cobraCharmer/cobraCoach/trajectory.py
+++ b/python/ics/cobraCharmer/cobraCoach/trajectory.py
@@ -1,4 +1,5 @@
 import numpy as np
+from ics.cobraCharmer import targetValidation
 
 
 class Trajectories():
@@ -63,7 +64,8 @@ class Trajectories():
         """
         # Create the arrays for the new movement information
         movementSteps = thetaAngles.shape[1]
-        newThetaAngles = np.zeros((self.nCobras, movementSteps))+((self.calibModel.tht1 - self.calibModel.tht0 + np.pi) % (np.pi * 2) + np.pi)[:, np.newaxis]
+        newThetaAngles = (np.zeros((self.nCobras, movementSteps))
+                          + targetValidation.thetaRange(self.calibModel)[:, np.newaxis])
         newPhiAngles = np.zeros((self.nCobras, movementSteps))
 
         # update positions for moving cobras

--- a/python/ics/cobraCharmer/pfi.py
+++ b/python/ics/cobraCharmer/pfi.py
@@ -15,18 +15,20 @@ from ics.cobraCharmer import cobraState
 reload(pfiDesign)
 reload(func)
 
+from ics.cobraCharmer import targetValidation
+
 
 class PFI(object):
     nCobrasPerModule = 57
     nModules = 42
 
     # bit array for (x,y) to (theta, phi) convertion
-    SOLUTION_OK           = 0x0001  # 1 if the solution is valid
-    IN_OVERLAPPING_REGION = 0x0002  # 1 if the position in overlapping region
-    PHI_NEGATIVE          = 0x0004  # 1 if phi angle is negative(phi CCW limit < 0)
-    PHI_BEYOND_PI         = 0x0008  # 1 if phi angle is beyond PI(phi CW limit > PI)
-    TOO_CLOSE_TO_CENTER   = 0x0010  # 1 if the position is too close to the center
-    TOO_FAR_FROM_CENTER   = 0x0020  # 1 if the position is too far from the center
+    SOLUTION_OK           = targetValidation.SOLUTION_OK  # 1 if the solution is valid
+    IN_OVERLAPPING_REGION = targetValidation.IN_OVERLAPPING_REGION  # 1 if the position in overlapping region
+    PHI_NEGATIVE          = targetValidation.PHI_NEGATIVE  # 1 if phi angle is negative(phi CCW limit < 0)
+    PHI_BEYOND_PI         = targetValidation.PHI_BEYOND_PI  # 1 if phi angle is beyond PI(phi CW limit > PI)
+    TOO_CLOSE_TO_CENTER   = targetValidation.TOO_CLOSE_TO_CENTER  # 1 if the position is too close to the center
+    TOO_FAR_FROM_CENTER   = targetValidation.TOO_FAR_FROM_CENTER  # 1 if the position is too far from the center
 
     # on time vs speed model parameters
     thetaParameter = 0.09
@@ -353,7 +355,7 @@ class PFI(object):
         if thetaFroms is not None:
             _thetaFroms[cIdx] = thetaFroms
         elif not ccwLimit:
-            _thetaFroms = (self.calibModel.tht1 - self.calibModel.tht0 + np.pi) % (2*np.pi) + np.pi
+            _thetaFroms = targetValidation.thetaRange(self.calibModel)
 
         if isinstance(thetaFast, bool):
             _thetaFast = thetaFast
@@ -944,111 +946,13 @@ class PFI(object):
     def positionsToAngles(self, cobras, positions):
         """Convert the fiber positions to theta, phi angles from CCW limit.
 
-        Parameters
-        ----------
-        cobras: a list of cobras
-        positions: numpy array
-            A complex numpy array with the fiber positions.
-
-        Returns
-        -------
-        tuple
-            A python tuples with all the possible angles (theta, phi, flags).
-            Since there are possible 2 phi solutions (since phi CCW<0 and CW>PI)
-            so the dimensions of theta and phi are (len(cobras), 2), the value
-            np.nan indicates there is no solution. flags is a bit map.
-
-            There are several different cases:
-            - No solution: This means the distance from the given position to
-              the center and two arm lengths(theta, phi) can't form a triangle.
-              In this case, either TOO_CLOSE_TO_CENTER or TOO_FAR_FROM_CENTER
-              is set. For TOO_CLOSE_TO_CENTER case, phi is set to 0 and for
-              TOO_FAR_FROM_CENTER case, phi is set to PI, theta is set to
-              the angle from the center to the given position for both cases.
-            - Two phi solutions: This happens because the range of phi arms can
-              be negative and beyond PI. When the measured phi angle is small or
-              close to PI, this case may happen. The second solution is also
-              calculated and returned. The bit PHI_NEGATIVE or PHI_BEYOND_PI is
-              set in this situation. If this solution is within the hard stops,
-              the bit SOLUTION_OK is set.
-            - Theta overlapping region: Since theta arms can move beyond PI*2,
-              so in the overlapping region(between two hard stops) we have two
-              possible theta solutions. The bit IN_OVERLAPPING_REGION is set.
+        Thin wrapper: resolves cobras to indices and defers to the module-level
+        anglesFromPositions, which is the single implementation of this geometry.
         """
         if len(cobras) != len(positions):
             raise RuntimeError("number of positions must match number of cobras")
         cIdx = np.array([self._mapCobraIndex(c) for c in cobras])
-
-        # Calculate the cobras rotation angles applying the law of cosines
-        relativePositions = positions - self.calibModel.centers[cIdx]
-        distance = np.abs(relativePositions)
-        L1 = self.calibModel.L1[cIdx]
-        L2 = self.calibModel.L2[cIdx]
-        distanceSq = distance ** 2
-        L1Sq = L1 ** 2
-        L2Sq = L2 ** 2
-        phiIn = self.calibModel.phiIn[cIdx] + np.pi
-        phiOut = self.calibModel.phiOut[cIdx] + np.pi
-        tht0 = self.calibModel.tht0[cIdx]
-        tht1 = self.calibModel.tht1[cIdx]
-        phi = np.full((len(cobras), 2), np.nan)
-        tht = np.full((len(cobras), 2), np.nan)
-        flags = np.full((len(cobras), 2), 0, dtype='u2')
-
-        for i in range(len(positions)):
-            if L1[i] == 0 or L2[i] == 0:
-                # bad cobras
-                continue
-            if distance[i] > L1[i] + L2[i]:
-                # too far away, return theta= spot angle and phi=PI
-                flags[i][0] |= self.TOO_FAR_FROM_CENTER
-                phi[i][0] = np.pi
-                tht[i][0] = (np.angle(relativePositions[i]) - tht0[i]) % (2 * np.pi)
-                if tht[i][0] <= (tht1[i] - tht0[i]) % (2 * np.pi):
-                    flags[i][0] |= self.IN_OVERLAPPING_REGION
-                continue
-            if distance[i] < np.abs(L1[i] - L2[i]):
-                # too close to center, theta is undetermined, return theta=spot angle and phi=0
-                flags[i][0] |= self.TOO_CLOSE_TO_CENTER
-                phi[i][0] = 0
-                tht[i][0] = (np.angle(relativePositions[i]) - tht0[i]) % (2 * np.pi)
-                if tht[i][0] <= (tht1[i] - tht0[i]) % (2 * np.pi):
-                    flags[i][0] |= self.IN_OVERLAPPING_REGION
-                continue
-
-            ang1 = np.arccos((L1Sq[i] + L2Sq[i] - distanceSq[i]) / (2 * L1[i] * L2[i]))
-            ang2 = np.arccos((L1Sq[i] + distanceSq[i] - L2Sq[i]) / (2 * L1[i] * distance[i]))
-
-            # the regular solutions, phi angle is between 0 and pi, no checking for phi hard stops
-            flags[i][0] |= self.SOLUTION_OK
-            phi[i][0] = ang1 - phiIn[i]
-            tht[i][0] = (np.angle(relativePositions[i]) + ang2 - tht0[i]) % (2 * np.pi)
-            # check if tht is within two theta hard stops
-            if tht[i][0] <= (tht1[i] - tht0[i]) % (2 * np.pi):
-                flags[i][0] |= self.IN_OVERLAPPING_REGION
-
-            # check if there are additional solutions
-            if ang1 <= np.pi/2 and ang1 > 0:
-                if phiIn[i] <= -ang1:
-                    flags[i][1] |= self.SOLUTION_OK
-                flags[i][1] |= self.PHI_NEGATIVE
-                # phiIn < 0
-                phi[i][1] = -ang1 - phiIn[i]
-                tht[i][1] = (np.angle(relativePositions[i]) - ang2 - tht0[i]) % (2 * np.pi)
-                # check if tht is within two theta hard stops
-                if tht[i][1] <= (tht1[i] - tht0[i]) % (2 * np.pi):
-                    flags[i][1] |= self.IN_OVERLAPPING_REGION
-            elif ang1 > np.pi/2 and ang1 < np.pi:
-                if phiOut[i] >= 2 * np.pi - ang1:
-                    flags[i][1] |= self.SOLUTION_OK
-                flags[i][1] |= self.PHI_BEYOND_PI
-                # phiOut > np.pi
-                phi[i][1] = 2 * np.pi - ang1 - phiIn[i]
-                tht[i][1] = (np.angle(relativePositions[i]) - ang2 - tht0[i]) % (2 * np.pi)
-                # check if tht is within two theta hard stops
-                if tht[i][1] <= (tht1[i] - tht0[i]) % (2 * np.pi):
-                    flags[i][1] |= self.IN_OVERLAPPING_REGION
-        return (tht, phi, flags)
+        return targetValidation.anglesFromPositions(self.calibModel, cIdx, positions)
 
     def moveXY(self, cobras, startPositions, targetPositions, overlappingCW=False,
                thetaThreshold=1e10, phiThreshold=1e10, delta=10.0):

--- a/python/ics/cobraCharmer/targetValidation.py
+++ b/python/ics/cobraCharmer/targetValidation.py
@@ -1,0 +1,454 @@
+"""targetValidation.py — is a commanded target actually reachable and safe?
+
+One implementation, shared by the targeting software and by fps at move time.  They
+must agree: targeting guarantees a design is in spec, but fps applies a last-minute
+tweak for proper motion and parallax immediately before moving, so what is finally
+commanded is not quite what was validated upstream.  Re-checking at run time is only
+meaningful if it asks exactly the same question, with exactly the same geometry.
+
+Everything here is stateless and needs only a calibModel: no PFI, no connection, no
+CobraCoach.  The angle solve lives here, and PFI.positionsToAngles is a thin wrapper
+over it, so the two cannot drift apart.
+
+Every array is (nCobras,) and indexed by cobra index throughout -- never a subset,
+never a list of indices into a subset.  Subsetting is where this kind of code goes
+wrong: a mask over good cobras and a mask over all cobras look identical and cannot
+be told apart by a reader or a test.  Callers subset at the very end, if at all.
+"""
+import numpy as np
+
+# ── flags ─────────────────────────────────────────────────────────────────────
+# Kinematic flags, describing the angle solve itself.  Module level so
+# anglesFromPositions and PFI share one definition rather than each declaring a copy.
+SOLUTION_OK = 0x0001  # 1 if the solution is valid
+IN_OVERLAPPING_REGION = 0x0002  # 1 if the position in overlapping region
+PHI_NEGATIVE = 0x0004  # 1 if phi angle is negative(phi CCW limit < 0)
+PHI_BEYOND_PI = 0x0008  # 1 if phi angle is beyond PI(phi CW limit > PI)
+TOO_CLOSE_TO_CENTER = 0x0010  # 1 if the position is too close to the center
+TOO_FAR_FROM_CENTER = 0x0020  # 1 if the position is too far from the center
+
+# Validation flags: the per-cobra verdict, as bits so a caller can both compose masks
+# and report a breakdown.  0 means the target is good.
+# Deliberately disjoint from the kinematic bits above.  The two sets share a module and
+# a return value, so overlapping values would let a caller mix vocabularies and get a
+# plausible wrong answer.  Disjoint by construction instead.
+NOT_FINITE = 0x0100  # NaN in the design's pfiNominal
+FIDUCIAL = 0x0200  # the arm would interfere with a fiducial fiber
+
+# There is no out-of-reach bit.  anglesFromPositions abandons the solve the moment a
+# target falls outside the annulus, so SOLUTION_OK-clear IS out of reach -- verified
+# identical over 95760 targets.  Use isInvalid() rather than testing a mask, because
+# "no solution" is the ABSENCE of a bit and cannot be expressed as one.
+
+FLAG_NAMES = {NOT_FINITE: 'non-finite target', FIDUCIAL: 'fiducial interference',
+              TOO_CLOSE_TO_CENTER: 'too close to centre',
+              TOO_FAR_FROM_CENTER: 'too far from centre',
+              IN_OVERLAPPING_REGION: 'theta overlap'}
+
+
+# ── functions ─────────────────────────────────────────────────────────────────
+def anglesFromPositions(calibModel, cIdx, positions):
+    """Convert fiber positions to theta, phi angles from the CCW limit.
+
+    Solves the two-link geometry from a calibModel alone: no PFI, no connection.
+
+    Parameters
+    ----------
+    calibModel : PFIDesign
+        Cobra calibration model.
+    cIdx : ndarray of int
+        Cobra indices (0-based) the positions correspond to.
+    positions : ndarray of complex
+        Fiber positions, same length as cIdx.
+
+    Returns
+    -------
+    (tht, phi, flags) : each (len(cIdx), 2)
+        Both possible solutions per cobra, with the flag bits below describing each.
+    """
+
+    # Calculate the cobras rotation angles applying the law of cosines
+    relativePositions = positions - calibModel.centers[cIdx]
+    distance = np.abs(relativePositions)
+    L1 = calibModel.L1[cIdx]
+    L2 = calibModel.L2[cIdx]
+    # Reach comes from the phi hard stops, not |L1-L2|..L1+L2 -- the latter assumes
+    # phi reaches -pi and 0, which no cobra does (1278 cannot fold that far, 134
+    # cannot extend that far).  Using it accepted targets needing a NEGATIVE phi,
+    # i.e. the arm folding past its own stop.
+    _rMin, _rMax = reachAnnulus(calibModel)
+    rMin, rMax = _rMin[cIdx], _rMax[cIdx]
+    distanceSq = distance ** 2
+    L1Sq = L1 ** 2
+    L2Sq = L2 ** 2
+    phiIn = calibModel.phiIn[cIdx] + np.pi
+    phiOut = calibModel.phiOut[cIdx] + np.pi
+    tht0 = calibModel.tht0[cIdx]
+    tht1 = calibModel.tht1[cIdx]
+    phi = np.full((len(cIdx), 2), np.nan)
+    tht = np.full((len(cIdx), 2), np.nan)
+    flags = np.full((len(cIdx), 2), 0, dtype='u2')
+
+    for i in range(len(positions)):
+        if L1[i] == 0 or L2[i] == 0:
+            # bad cobras
+            continue
+        if distance[i] > rMax[i]:
+            # too far away, return theta= spot angle and phi=PI
+            flags[i][0] |= TOO_FAR_FROM_CENTER
+            phi[i][0] = np.pi
+            tht[i][0] = (np.angle(relativePositions[i]) - tht0[i]) % (2 * np.pi)
+            if tht[i][0] <= (tht1[i] - tht0[i]) % (2 * np.pi):
+                flags[i][0] |= IN_OVERLAPPING_REGION
+            continue
+        if distance[i] < rMin[i]:
+            # too close to center, theta is undetermined, return theta=spot angle and phi=0
+            flags[i][0] |= TOO_CLOSE_TO_CENTER
+            phi[i][0] = 0
+            tht[i][0] = (np.angle(relativePositions[i]) - tht0[i]) % (2 * np.pi)
+            if tht[i][0] <= (tht1[i] - tht0[i]) % (2 * np.pi):
+                flags[i][0] |= IN_OVERLAPPING_REGION
+            continue
+
+        ang1 = np.arccos((L1Sq[i] + L2Sq[i] - distanceSq[i]) / (2 * L1[i] * L2[i]))
+        ang2 = np.arccos((L1Sq[i] + distanceSq[i] - L2Sq[i]) / (2 * L1[i] * distance[i]))
+
+        # the regular solutions, phi angle is between 0 and pi, no checking for phi hard stops
+        flags[i][0] |= SOLUTION_OK
+        phi[i][0] = ang1 - phiIn[i]
+        tht[i][0] = (np.angle(relativePositions[i]) + ang2 - tht0[i]) % (2 * np.pi)
+        # check if tht is within two theta hard stops
+        if tht[i][0] <= (tht1[i] - tht0[i]) % (2 * np.pi):
+            flags[i][0] |= IN_OVERLAPPING_REGION
+
+        # check if there are additional solutions
+        if np.pi / 2 >= ang1 > 0:
+            if phiIn[i] <= -ang1:
+                flags[i][1] |= SOLUTION_OK
+            flags[i][1] |= PHI_NEGATIVE
+            # phiIn < 0
+            phi[i][1] = -ang1 - phiIn[i]
+            tht[i][1] = (np.angle(relativePositions[i]) - ang2 - tht0[i]) % (2 * np.pi)
+            # check if tht is within two theta hard stops
+            if tht[i][1] <= (tht1[i] - tht0[i]) % (2 * np.pi):
+                flags[i][1] |= IN_OVERLAPPING_REGION
+        elif np.pi / 2 < ang1 < np.pi:
+            if phiOut[i] >= 2 * np.pi - ang1:
+                flags[i][1] |= SOLUTION_OK
+            flags[i][1] |= PHI_BEYOND_PI
+            # phiOut > np.pi
+            phi[i][1] = 2 * np.pi - ang1 - phiIn[i]
+            tht[i][1] = (np.angle(relativePositions[i]) - ang2 - tht0[i]) % (2 * np.pi)
+            # check if tht is within two theta hard stops
+            if tht[i][1] <= (tht1[i] - tht0[i]) % (2 * np.pi):
+                flags[i][1] |= IN_OVERLAPPING_REGION
+    return tht, phi, flags
+
+
+def isInvalid(flags):
+    """A target was requested for this cobra and cannot be commanded.
+
+    NOT_FINITE is excluded on purpose: a target that was never given a position is
+    not a target the cobra failed to reach, and conflating them makes an ordinary
+    design look out of spec.
+
+    Parameters
+    ----------
+    flags : ndarray of uint16, (nCobras,)
+        Per-cobra verdict from validateTargets.
+
+    Returns
+    -------
+    ndarray of bool, (nCobras,)
+        True where the cobra has a target it cannot be commanded to.
+    """
+    hasTarget = (flags & NOT_FINITE) == 0
+    return hasTarget & (((flags & SOLUTION_OK) == 0) | ((flags & FIDUCIAL) != 0))
+
+
+def loadFidAvoidance():
+    """Per-cobra fiducial avoidance limits, one row per cobra in cobra_id order.
+
+    Columns theta_limit_1, theta_limit_2 and max_phi_angle; NaN means the cobra is
+    unconstrained.  Read from the butler; needs no calibModel.
+
+    Raises whatever the butler raises: the table ships with pfs_instdata, so its
+    absence is a broken installation and the underlying error says which.
+
+    Returns
+    -------
+    DataFrame
+        Columns cobra_id, theta_limit_1, theta_limit_2, max_phi_angle.
+    """
+    # Imported here, not at module scope: the reach test needs no butler at all, and
+    # pfs.utils is not otherwise a dependency of this package, so the reach test stays
+    # usable without pfs_utils set up.
+    from pfs.utils import butler
+
+    return butler.Butler().get('cobraInterference')
+
+
+def thetaRange(calibModel):
+    """Angular travel of each theta stage, CCW hard stop to CW hard stop, in radians.
+
+    Slightly more than 2*pi -- the two hard stops overlap by ~20 deg by design, so a
+    target within that wedge is reachable at two local angles.  The +pi/-pi framing is what makes the result land in [pi, 3*pi) instead
+    of wrapping the overlap back to near zero, which is the whole point: writing the
+    modulo without it silently turns a 380 deg range into a 20 deg one.
+
+    Parameters
+    ----------
+    calibModel : PFIDesign
+        Cobra calibration model.
+
+    Returns
+    -------
+    ndarray of float, (nCobras,)
+        Theta travel per cobra in radians, in [pi, 3*pi).
+    """
+    return (calibModel.tht1 - calibModel.tht0 + np.pi) % (np.pi * 2) + np.pi
+
+
+def reachAnnulus(calibModel):
+    """Inner and outer radius each cobra's fiber can reach, from its centre.
+
+    Derived from the phi hard stops rather than from |L1-L2| and L1+L2, which assume
+    phi can reach -pi and 0 exactly.  It cannot: phiIn and phiOut are per-cobra and
+    the arm is correspondingly less able to fold or extend.  Using the loose bound
+    passes targets the cobra cannot actually reach -- on the current model it is wrong
+    by more than 0.1 mm for 364 cobras.
+
+    No safety margin is applied; see applySafetyMargin.
+
+    Parameters
+    ----------
+    calibModel : PFIDesign
+        Cobra calibration model.
+
+    Returns
+    -------
+    rMin, rMax : ndarray of float, (nCobras,)
+        Inner and outer reach radius per cobra, in mm.
+    """
+    rMin = np.abs(calibModel.L1
+                  + calibModel.L2 * np.exp(1j * np.maximum(-np.pi, calibModel.phiIn)))
+    rMax = np.abs(calibModel.L1
+                  + calibModel.L2 * np.exp(1j * np.minimum(calibModel.phiOut, 0)))
+    return rMin, rMax
+
+
+def applySafetyMargin(rMin, rMax, safetyMargin, maximumDistance=np.inf):
+    """Shrink a reach annulus to what an assignment run will actually accept.
+
+    The margin is added to rMin and taken off rMax; maximumDistance caps rMax on top
+    of that, so one call gives the effective annulus.
+
+    Scalars or arrays.  A margin large enough to invert the annulus is not rejected:
+    rMin then exceeds rMax and nothing is accepted.
+
+    Parameters
+    ----------
+    rMin, rMax : float or ndarray
+        Reach annulus to shrink, as returned by reachAnnulus.
+    safetyMargin : float
+        Millimetres to shave off each end.
+    maximumDistance : float, optional
+        Hard cap on rMax, applied after the margin.  No cap by default.
+
+    Returns
+    -------
+    rMin, rMax : same shape as the inputs
+        The effective annulus.
+    """
+    return rMin + safetyMargin, np.minimum(rMax - safetyMargin, maximumDistance)
+
+
+def validateTargets(calibModel, targets, skipFiducialInterferenceCheck=False):
+    """Per-cobra verdict on commanded target positions.
+
+    Parameters
+    ----------
+    calibModel : PFIDesign
+        Cobra calibration model; also the source of truth for which cobras are broken.
+    targets : ndarray of complex, (nCobras,)
+        Commanded position per cobra, NaN where the design assigns none.
+    skipFiducialInterferenceCheck : bool, optional
+        Leave FIDUCIAL unset without testing it.  The bit is then absent because it
+        was never measured, not because the arm is clear.
+
+    Returns
+    -------
+    flags : ndarray uint16, (nCobras,)
+        0 where the target is good, otherwise a bitwise-or of the constants above.
+    """
+    targets = np.asarray(targets)
+    nCobras = len(calibModel.centers)
+    if targets.shape != (nCobras,):
+        raise ValueError(f'targets must have shape ({nCobras},), got {targets.shape}')
+
+    flags = np.zeros(nCobras, dtype='u2')
+
+    notFinite = np.isnan(targets.real) | np.isnan(targets.imag)
+    flags[notFinite] |= NOT_FINITE
+
+    # Only targets with a position are judged: having none is not a validation
+    # failure, it is reported as NOT_FINITE and left at that.
+    idx = np.flatnonzero(~notFinite)
+    if len(idx) == 0:
+        return flags
+
+    # Reach comes straight from the solve, so the verdict cannot disagree with
+    # SOLUTION_OK.  Bounds are asymmetric on purpose -- the accepted range is
+    # (rMin, rMax] -- because that is what the targeting side does: TargetSelector
+    # uses `distances > rMin` and query_ball_point is inclusive at rMax.
+    _, _, solFlags = anglesFromPositions(calibModel, idx, targets[idx])
+    flags[idx] |= solFlags[:, 0].astype(flags.dtype)
+
+    if not skipFiducialInterferenceCheck:
+        fidAvoidance = loadFidAvoidance()
+        flags[fiducialInterference(calibModel, targets, fidAvoidance)] |= FIDUCIAL
+
+    return flags
+
+
+def fiducialInterference(calibModel, targets, fidAvoidance):
+    """Cobras whose arm would interfere with a fiducial fiber at its target.
+
+    A cobra interferes when its phi exceeds the row's maximum AND either the theta
+    arm or the fiber tip lies inside the forbidden theta window.  The window wraps:
+    `limit1 > limit2` means it spans 0 degrees.  Rows with no limits (the "no
+    collision" entries) constrain nothing.
+
+    Parameters
+    ----------
+    calibModel : PFIDesign
+        Cobra calibration model.
+    targets : ndarray of complex, (nCobras,)
+        Commanded position per cobra, NaN where the design assigns none.
+    fidAvoidance : DataFrame
+        Per-cobra fiducial avoidance limits, from loadFidAvoidance.
+
+    Returns
+    -------
+    ndarray of bool, (nCobras,)
+        True where the arm would interfere with a fiducial fiber.
+    """
+    targets = np.asarray(targets)
+    nCobras = len(calibModel.centers)
+
+    assigned = ~(np.isnan(targets.real) | np.isnan(targets.imag))
+    thetas = np.full(nCobras, np.nan)
+    phis = np.full(nCobras, np.nan)
+    if assigned.any():
+        idx = np.flatnonzero(assigned)
+        tht, phi, _ = anglesFromPositions(calibModel, idx, targets[idx])
+        thetas[idx], phis[idx] = tht[:, 0], phi[:, 0]
+
+    return fiducialInterferenceFromAngles(calibModel, thetas, phis, fidAvoidance)
+
+
+def fiducialInterferenceFromAngles(calibModel, thetas, phis, fidAvoidance):
+    """As fiducialInterference, but from local angles that are already known.
+
+    Where the test is implemented.  Working from angles skips the solve, and avoids
+    resolving a position back onto the other branch in the overlapping region.
+
+    Parameters
+    ----------
+    calibModel : PFIDesign
+        Cobra calibration model.
+    thetas, phis : ndarray of float, (nCobras,)
+        Local angles in radians, NaN where the cobra has no target.
+    fidAvoidance : DataFrame or None
+        Per-cobra fiducial avoidance limits.  Nothing interferes when None.
+
+    Returns
+    -------
+    ndarray of bool, (nCobras,)
+        True where the arm would interfere with a fiducial fiber.
+    """
+    thetas = np.asarray(thetas, dtype=float)
+    phis = np.asarray(phis, dtype=float)
+    nCobras = len(calibModel.centers)
+    out = np.zeros(nCobras, dtype=bool)
+
+    assigned = np.flatnonzero(np.isfinite(thetas) & np.isfinite(phis))
+    if len(assigned) == 0 or fidAvoidance is None:
+        return out
+
+    lo = fidAvoidance.theta_limit_1.to_numpy()[assigned]
+    hi = fidAvoidance.theta_limit_2.to_numpy()[assigned]
+    maxPhi = fidAvoidance.max_phi_angle.to_numpy()[assigned]
+    constrained = ~(np.isnan(lo) | np.isnan(hi) | np.isnan(maxPhi))
+    if not constrained.any():
+        return out
+
+    thetaDeg = np.rad2deg((thetas[assigned] + calibModel.tht0[assigned]) % (2 * np.pi))
+    # No modulo on phi.  Local phi legitimately exceeds 180 degrees -- 2354 of 2394
+    # cobras have a span wider than that -- and folding it would turn 188.9 into 8.9,
+    # which passes a 60-161 degree limit and silently clears the test at full
+    # extension, exactly where interference is most likely.
+    phiDeg = np.rad2deg(phis[assigned])
+
+    # Angle of the fiber tip about the cobra centre.  Checked as well as theta because
+    # the elbow can clear a fiducial while the tip does not.
+    ang1 = calibModel.tht0[assigned] + np.deg2rad(thetaDeg)
+    ang2 = ang1 + np.deg2rad(phiDeg) + calibModel.phiIn[assigned]
+    endDeg = np.rad2deg(np.angle(calibModel.L1[assigned] * np.exp(1j * ang1)
+                                 + calibModel.L2[assigned] * np.exp(1j * ang2))
+                        - calibModel.tht0[assigned]) % 360
+
+    hit = constrained & (phiDeg > maxPhi) & (_inWindow(thetaDeg, lo, hi)
+                                             | _inWindow(endDeg, lo, hi))
+    out[assigned[hit]] = True
+    return out
+
+
+def _inWindow(angleDeg, lo, hi):
+    """Whether each angle falls inside [lo, hi], elementwise.
+
+    The window wraps through zero when lo > hi, which is not an edge case: several
+    cobras have forbidden ranges straddling 0 degrees.
+
+    Parameters
+    ----------
+    angleDeg : ndarray of float
+        Angles to test, in degrees.
+    lo, hi : ndarray of float
+        Window bounds in degrees, same shape as angleDeg.
+
+    Returns
+    -------
+    ndarray of bool
+        True where the angle lies inside the window.
+    """
+    wrapped = lo > hi
+    return np.where(wrapped,
+                    (angleDeg >= lo) | (angleDeg <= hi),
+                    (angleDeg >= lo) & (angleDeg <= hi))
+
+
+def summarise(flags, isScience=None):
+    """Counts per failure mode, for logging and for the out-of-spec decision.
+
+    isScience restricts the tally to cobras carrying a science-class target: an
+    cobra with no position failing validation is not a design defect.
+
+    Parameters
+    ----------
+    flags : ndarray of uint16, (nCobras,)
+        Per-cobra verdict from validateTargets.
+    isScience : ndarray of bool, (nCobras,), optional
+        Restrict the tally to these cobras.  All of them when None.
+
+    Returns
+    -------
+    dict
+        One entry per FLAG_NAMES bit, plus 'invalid' and 'checked'.
+    """
+    mask = np.ones(len(flags), dtype=bool) if isScience is None else np.asarray(isScience)
+    counts = {name: int(np.sum(((flags & bit) != 0) & mask))
+              for bit, name in FLAG_NAMES.items()}
+    counts['invalid'] = int(np.sum(isInvalid(flags) & mask))
+    counts['checked'] = int(mask.sum())
+    return counts


### PR DESCRIPTION
targetValidation answers "is this target commandable" for both the targeting software and fps at move time, so the two cannot disagree. It owns the kinematics: anglesFromPositions moves here from PFI.positionsToAngles, which becomes a thin wrapper, and PFI aliases the solution flags rather than declaring its own copies.

Reach comes from the phi hard stops, not |L1-L2| and L1+L2, which assume phi reaches -pi and 0. 1278 cobras cannot fold that far, 134 cannot extend that far, and every target the loose bound accepted and the tight one rejects needs a NEGATIVE phi -- the arm folding through its own stop. It affected 0.35% of real design targets.

One vocabulary, one answer. The annulus test moves inside the solve, so a reach verdict cannot disagree with SOLUTION_OK; the redundant OUT_OF_REACH and NO_SOLUTION bits are gone and isInvalid() replaces the INVALID mask. Validation-only bits sit at 0x0100 and above, disjoint from the kinematic ones.

safetyMargin is the one thing callers should differ on, so it is a parameter: targeting leaves room for target drift between design and observation, fps passes zero because by move time the drift has happened and masking a science target cannot be undone.

The theta range was copy-pasted at fourteen sites across two packages in three spellings; targetValidation.thetaRange is now its only definition. The +pi/-pi framing is what keeps the hard-stop overlap in the result, so a stray parenthesis in one copy turns a 380 degree range into a 20 degree one -- a plausible number rather than an error.

checkFiducialInterference becomes a shim over
fiducialInterferenceFromAngles, which works in (nCobras,) and reads NaN as "no target": callers no longer subset to goodIdx and map indices back. The dead _loadcobraInterferenceTable goes with it, taking the butler key this ticket renamed.

The phi modulo is removed from the interference test. Local phi legitimately exceeds 180 degrees on 2354 of 2394 cobras, and folding it turned 188.9 into 8.9, clearing the test at full extension -- exactly where interference is most likely.